### PR TITLE
chore: update npm publish command to use public access

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -130,7 +130,7 @@ jobs:
         if: steps.version_check.outputs.should_publish == 'true'
         run: |
           cd create-package
-          npm publish
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
- Modified the npm publish command in the GitHub Actions workflow to include the --access public flag, ensuring that the package is published with public access.

This change enhances the visibility of the published package.