### PR TITLE
chore: remove private flag from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "docker:dev": "docker-compose -f docker-compose.dev.yml up",
     "graph": "nx graph"
   },
-  "private": true,
   "devDependencies": {
     "@eslint/js": "^9.8.0",
     "@nestjs/schematics": "^11.0.0",


### PR DESCRIPTION
- Removed the "private" flag from package.json, allowing the package to be published publicly. This change aligns with recent updates to the npm publish command.