### PR TITLE
chore: update GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # Fetch full history for version calculation
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}  # Fetch full history for version calculation
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -91,7 +95,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create Git tag
+      - name: Create Git tag and push
         if: steps.version_check.outputs.should_publish == 'true'
         run: |
           git config user.name "GitHub Actions"


### PR DESCRIPTION
- Added permissions for write access to contents and id-token in the publish job.
- Updated the checkout step to include the GitHub token for fetching full history.
- Renamed the Git tag creation step to clarify that it also pushes the tag.