### PR TITLE
chore: add CODEOWNERS file to define code ownership for project compo…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Global code owners
+* @anadi45
+
+# Package-specific owners
+/create-package/ @anadi45
+/bin/ @anadi45
+
+# Documentation
+README.md @anadi45
+LICENSE @anadi45
+
+# GitHub workflows
+/.github/ @anadi45


### PR DESCRIPTION
…nents

- Introduced a CODEOWNERS file to specify ownership for global, package-specific, documentation, and GitHub workflow files, assigning @anadi45 as the owner for all sections.